### PR TITLE
Fix Google TTS dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ PyMuPDF==1.22.5
 python-dotenv==1.0.0
 requests==2.31.0
 pydub==0.25.1
-google-cloud-texttospeech==2.13.1
+# 2.13.1 was never released on PyPI. Using the latest 2.13.x version.
+google-cloud-texttospeech==2.13.0


### PR DESCRIPTION
## Summary
- correct the google-cloud-texttospeech version in requirements

## Testing
- `pip install -r requirements.txt`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_683f50df4cec832fb921e6efd3a30185